### PR TITLE
Add fuzzy image matching utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# Fuzzy-image-matching
+# Fuzzy Image Matching
+
+A Python utility for fuzzy image matching using a combination of ORB feature matching, color histogram comparison, and Structural Similarity Index (SSIM).
+
+## Features
+
+- Compare a query image against one or more candidate images or directories.
+- Combines multiple similarity metrics with configurable weights.
+- Command line interface for quick usage.
+
+## Requirements
+
+- Python 3.9+
+- `opencv-python`
+- `scikit-image`
+- `numpy`
+
+Install dependencies using pip:
+
+```bash
+pip install opencv-python scikit-image numpy
+```
+
+## Usage
+
+Run the matcher from the project root:
+
+```bash
+python -m fuzzy_image_matching.cli <query_image> <candidate1> [<candidate2> ...] [options]
+```
+
+You can pass directories as candidate arguments to compare against all files in the directory.
+
+### Options
+
+- `--weights ORB HIST SSIM`: Custom weights for ORB, histogram, and SSIM scores. Defaults to `0.4 0.3 0.3`.
+- `--top N`: Limit the output to the top N matches (defaults to 5).
+
+### Example
+
+```bash
+python -m fuzzy_image_matching.cli ./examples/query.jpg ./examples/candidates --top 3
+```
+
+This will output the top three matches and show the individual metric contributions.
+
+## Project Structure
+
+```
+fuzzy_image_matching/
+├── __init__.py
+├── cli.py
+└── matching.py
+```
+
+## License
+
+MIT

--- a/fuzzy_image_matching/__init__.py
+++ b/fuzzy_image_matching/__init__.py
@@ -1,0 +1,17 @@
+"""Fuzzy image matching package."""
+
+from .matching import (
+    FuzzyImageMatcher,
+    MatchResult,
+    compute_histogram_similarity,
+    compute_orb_similarity,
+    compute_ssim_similarity,
+)
+
+__all__ = [
+    "FuzzyImageMatcher",
+    "MatchResult",
+    "compute_histogram_similarity",
+    "compute_orb_similarity",
+    "compute_ssim_similarity",
+]

--- a/fuzzy_image_matching/cli.py
+++ b/fuzzy_image_matching/cli.py
@@ -1,0 +1,75 @@
+"""Command line interface for fuzzy image matching."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from .matching import FuzzyImageMatcher
+
+
+class ExistingPath(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        path = Path(values)
+        if not path.exists():
+            parser.error(f"Path does not exist: {path}")
+        setattr(namespace, self.dest, path)
+
+
+def _iter_candidate_paths(path: Path) -> Iterable[Path]:
+    if path.is_dir():
+        yield from sorted(p for p in path.iterdir() if p.is_file())
+    else:
+        yield path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fuzzy image matcher")
+    parser.add_argument("query", action=ExistingPath, help="Query image")
+    parser.add_argument(
+        "candidates",
+        nargs="+",
+        help="Candidate image files or directories",
+    )
+    parser.add_argument(
+        "--weights",
+        type=float,
+        nargs=3,
+        metavar=("ORB", "HIST", "SSIM"),
+        help="Weights for similarity metrics (default: 0.4 0.3 0.3)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="Number of top matches to show",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    matcher = FuzzyImageMatcher(weights=args.weights)
+    candidate_files: list[Path] = []
+    for candidate in args.candidates:
+        candidate_files.extend(_iter_candidate_paths(Path(candidate)))
+
+    results = matcher.match(args.query, candidate_files)
+    top_n = args.top if args.top > 0 else len(results)
+
+    print(f"Query image: {args.query}")
+    print("Candidates scored (higher is better):")
+    for result in results[:top_n]:
+        print(
+            f"  {result.candidate}: score={result.score:.3f} "
+            f"(ORB={result.orb:.3f}, HIST={result.histogram:.3f}, SSIM={result.ssim:.3f})"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/fuzzy_image_matching/matching.py
+++ b/fuzzy_image_matching/matching.py
@@ -1,0 +1,113 @@
+"""Fuzzy image matching utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+import cv2
+import numpy as np
+from skimage.metrics import structural_similarity
+
+
+def _load_image(path: Path) -> np.ndarray:
+    """Load an image from disk and ensure it is in BGR format."""
+    image = cv2.imread(str(path))
+    if image is None:
+        raise FileNotFoundError(f"Could not read image at {path}")
+    return image
+
+
+def _ensure_gray(image: np.ndarray) -> np.ndarray:
+    if len(image.shape) == 3:
+        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    return image
+
+
+def compute_orb_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute similarity score based on ORB feature matching.
+
+    Returns a score between 0 and 1.
+    """
+    orb = cv2.ORB_create()
+    keypoints1, descriptors1 = orb.detectAndCompute(img1, None)
+    keypoints2, descriptors2 = orb.detectAndCompute(img2, None)
+
+    if descriptors1 is None or descriptors2 is None or len(keypoints1) == 0:
+        return 0.0
+
+    matcher = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+    matches = matcher.match(descriptors1, descriptors2)
+    if not matches:
+        return 0.0
+
+    distances = np.array([m.distance for m in matches], dtype=np.float32)
+    score = np.exp(-distances.mean() / 50.0)
+    return float(np.clip(score, 0.0, 1.0))
+
+
+def compute_histogram_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute similarity using color histograms."""
+    img1_hsv = cv2.cvtColor(img1, cv2.COLOR_BGR2HSV)
+    img2_hsv = cv2.cvtColor(img2, cv2.COLOR_BGR2HSV)
+
+    hist_size = [8, 8, 8]
+    ranges = [0, 180, 0, 256, 0, 256]
+    channels = [0, 1, 2]
+
+    hist1 = cv2.calcHist([img1_hsv], channels, None, hist_size, ranges)
+    hist2 = cv2.calcHist([img2_hsv], channels, None, hist_size, ranges)
+
+    cv2.normalize(hist1, hist1)
+    cv2.normalize(hist2, hist2)
+
+    score = cv2.compareHist(hist1, hist2, cv2.HISTCMP_CORREL)
+    score = (score + 1) / 2  # convert to 0-1
+    return float(np.clip(score, 0.0, 1.0))
+
+
+def compute_ssim_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute Structural Similarity Index (SSIM)."""
+    gray1 = _ensure_gray(img1)
+    gray2 = _ensure_gray(img2)
+    gray2_resized = cv2.resize(gray2, (gray1.shape[1], gray1.shape[0]))
+    score, _ = structural_similarity(gray1, gray2_resized, full=True)
+    return float(np.clip(score, 0.0, 1.0))
+
+
+@dataclass
+class MatchResult:
+    candidate: Path
+    score: float
+    orb: float
+    histogram: float
+    ssim: float
+
+
+class FuzzyImageMatcher:
+    """Match a query image against a collection of candidate images."""
+
+    def __init__(self, weights: Sequence[float] | None = None) -> None:
+        if weights is None:
+            weights = (0.4, 0.3, 0.3)
+        if len(weights) != 3:
+            raise ValueError("weights must contain exactly three values")
+        self.weights = np.array(weights, dtype=np.float32)
+
+    def score_pair(self, img1: np.ndarray, img2: np.ndarray) -> Tuple[float, float, float, float]:
+        orb = compute_orb_similarity(img1, img2)
+        hist = compute_histogram_similarity(img1, img2)
+        ssim = compute_ssim_similarity(img1, img2)
+        score = float(np.clip(np.dot(self.weights, np.array([orb, hist, ssim], dtype=np.float32)), 0.0, 1.0))
+        return score, orb, hist, ssim
+
+    def match(self, query: Path, candidates: Iterable[Path]) -> List[MatchResult]:
+        query_img = _load_image(query)
+        results: List[MatchResult] = []
+        for candidate in candidates:
+            candidate_img = _load_image(candidate)
+            score, orb, hist, ssim = self.score_pair(query_img, candidate_img)
+            results.append(MatchResult(candidate, score, orb, hist, ssim))
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results


### PR DESCRIPTION
## Summary
- add a reusable fuzzy image matching module combining ORB, color histogram, and SSIM metrics
- expose a command line interface for scoring a query image against candidate images or directories
- document installation requirements and usage instructions

## Testing
- python -m compileall fuzzy_image_matching

------
https://chatgpt.com/codex/tasks/task_e_68db86319280832c8251207d77583df7