### PR TITLE
Improve error handling for fuzzy matcher UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# Fuzzy-image-matching
+# Fuzzy Image Matching
+
+A Python utility for fuzzy image matching using a combination of ORB feature matching, color histogram comparison, and Structural Similarity Index (SSIM).
+
+## Features
+
+- Compare a query image against one or more candidate images or directories.
+- Combines multiple similarity metrics with configurable weights.
+- Command line interface for quick usage.
+- Minimal web UI for running comparisons without the terminal.
+
+## Requirements
+
+- Python 3.9+
+- `opencv-python`
+- `scikit-image`
+- `numpy`
+
+Install dependencies using pip:
+
+```bash
+pip install opencv-python scikit-image numpy
+```
+
+For the optional web interface install Flask as well:
+
+```bash
+pip install flask
+```
+
+## Usage
+
+Run the matcher from the project root:
+
+```bash
+python -m fuzzy_image_matching.cli <query_image> <candidate1> [<candidate2> ...] [options]
+```
+
+You can pass directories as candidate arguments to compare against all files in the directory.
+
+### Options
+
+- `--weights ORB HIST SSIM`: Custom weights for ORB, histogram, and SSIM scores. Defaults to `0.4 0.3 0.3`.
+- `--top N`: Limit the output to the top N matches (defaults to 5).
+
+### Example
+
+```bash
+python -m fuzzy_image_matching.cli ./examples/query.jpg ./examples/candidates --top 3
+```
+
+This will output the top three matches and show the individual metric contributions.
+
+## Web UI
+
+Launch the browser-based interface with Flask:
+
+```bash
+python -m flask --app fuzzy_image_matching.webapp run
+```
+
+Then open <http://localhost:5000> to upload a query image and one or more candidate images. You can adjust the metric weights and number of results directly in the interface, and the page will display previews and detailed scores for the best matches.
+
+## Project Structure
+
+```
+fuzzy_image_matching/
+├── __init__.py
+├── cli.py
+└── matching.py
+```
+
+## License
+
+MIT

--- a/fuzzy_image_matching/__init__.py
+++ b/fuzzy_image_matching/__init__.py
@@ -1,0 +1,19 @@
+"""Fuzzy image matching package."""
+
+from .matching import (
+    FuzzyImageMatcher,
+    ImageProcessingError,
+    MatchResult,
+    compute_histogram_similarity,
+    compute_orb_similarity,
+    compute_ssim_similarity,
+)
+
+__all__ = [
+    "FuzzyImageMatcher",
+    "ImageProcessingError",
+    "MatchResult",
+    "compute_histogram_similarity",
+    "compute_orb_similarity",
+    "compute_ssim_similarity",
+]

--- a/fuzzy_image_matching/cli.py
+++ b/fuzzy_image_matching/cli.py
@@ -1,0 +1,79 @@
+"""Command line interface for fuzzy image matching."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from .matching import FuzzyImageMatcher, ImageProcessingError
+
+
+class ExistingPath(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        path = Path(values)
+        if not path.exists():
+            parser.error(f"Path does not exist: {path}")
+        setattr(namespace, self.dest, path)
+
+
+def _iter_candidate_paths(path: Path) -> Iterable[Path]:
+    if path.is_dir():
+        yield from sorted(p for p in path.iterdir() if p.is_file())
+    else:
+        yield path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fuzzy image matcher")
+    parser.add_argument("query", action=ExistingPath, help="Query image")
+    parser.add_argument(
+        "candidates",
+        nargs="+",
+        help="Candidate image files or directories",
+    )
+    parser.add_argument(
+        "--weights",
+        type=float,
+        nargs=3,
+        metavar=("ORB", "HIST", "SSIM"),
+        help="Weights for similarity metrics (default: 0.4 0.3 0.3)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="Number of top matches to show",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    matcher = FuzzyImageMatcher(weights=args.weights)
+    candidate_files: list[Path] = []
+    for candidate in args.candidates:
+        candidate_files.extend(_iter_candidate_paths(Path(candidate)))
+
+    try:
+        results = matcher.match(args.query, candidate_files)
+    except (FileNotFoundError, ImageProcessingError) as exc:
+        parser.error(str(exc))
+
+    top_n = args.top if args.top > 0 else len(results)
+
+    print(f"Query image: {args.query}")
+    print("Candidates scored (higher is better):")
+    for result in results[:top_n]:
+        print(
+            f"  {result.candidate}: score={result.score:.3f} "
+            f"(ORB={result.orb:.3f}, HIST={result.histogram:.3f}, SSIM={result.ssim:.3f})"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/fuzzy_image_matching/matching.py
+++ b/fuzzy_image_matching/matching.py
@@ -1,0 +1,136 @@
+"""Fuzzy image matching utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+import cv2
+import numpy as np
+from skimage.metrics import structural_similarity
+
+
+class ImageProcessingError(Exception):
+    """Raised when an image cannot be processed for matching."""
+
+
+def _load_image(path: Path) -> np.ndarray:
+    """Load an image from disk and ensure it is in BGR format."""
+    image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if image is None:
+        raise FileNotFoundError(f"Could not read image at {path}")
+    return _ensure_bgr(image)
+
+
+def _ensure_gray(image: np.ndarray) -> np.ndarray:
+    if len(image.shape) == 3:
+        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    return image
+
+
+def _ensure_bgr(image: np.ndarray) -> np.ndarray:
+    """Convert grayscale or BGRA images to BGR."""
+    if image.ndim == 2:
+        return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+    if image.shape[2] == 4:
+        return cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+    return image
+
+
+def compute_orb_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute similarity score based on ORB feature matching.
+
+    Returns a score between 0 and 1.
+    """
+    orb = cv2.ORB_create()
+    keypoints1, descriptors1 = orb.detectAndCompute(img1, None)
+    keypoints2, descriptors2 = orb.detectAndCompute(img2, None)
+
+    if descriptors1 is None or descriptors2 is None or len(keypoints1) == 0:
+        return 0.0
+
+    matcher = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+    matches = matcher.match(descriptors1, descriptors2)
+    if not matches:
+        return 0.0
+
+    distances = np.array([m.distance for m in matches], dtype=np.float32)
+    score = np.exp(-distances.mean() / 50.0)
+    return float(np.clip(score, 0.0, 1.0))
+
+
+def compute_histogram_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute similarity using color histograms."""
+    img1_bgr = _ensure_bgr(img1)
+    img2_bgr = _ensure_bgr(img2)
+
+    img1_hsv = cv2.cvtColor(img1_bgr, cv2.COLOR_BGR2HSV)
+    img2_hsv = cv2.cvtColor(img2_bgr, cv2.COLOR_BGR2HSV)
+
+    hist_size = [8, 8, 8]
+    ranges = [0, 180, 0, 256, 0, 256]
+    channels = [0, 1, 2]
+
+    hist1 = cv2.calcHist([img1_hsv], channels, None, hist_size, ranges)
+    hist2 = cv2.calcHist([img2_hsv], channels, None, hist_size, ranges)
+
+    cv2.normalize(hist1, hist1)
+    cv2.normalize(hist2, hist2)
+
+    score = cv2.compareHist(hist1, hist2, cv2.HISTCMP_CORREL)
+    score = (score + 1) / 2  # convert to 0-1
+    return float(np.clip(score, 0.0, 1.0))
+
+
+def compute_ssim_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute Structural Similarity Index (SSIM)."""
+    gray1 = _ensure_gray(img1)
+    gray2 = _ensure_gray(img2)
+    if gray1.size == 0 or gray2.size == 0:
+        raise ImageProcessingError("Cannot compare empty images")
+    gray2_resized = cv2.resize(gray2, (gray1.shape[1], gray1.shape[0]))
+    score, _ = structural_similarity(gray1, gray2_resized, full=True)
+    return float(np.clip(score, 0.0, 1.0))
+
+
+@dataclass
+class MatchResult:
+    candidate: Path
+    score: float
+    orb: float
+    histogram: float
+    ssim: float
+
+
+class FuzzyImageMatcher:
+    """Match a query image against a collection of candidate images."""
+
+    def __init__(self, weights: Sequence[float] | None = None) -> None:
+        if weights is None:
+            weights = (0.4, 0.3, 0.3)
+        if len(weights) != 3:
+            raise ValueError("weights must contain exactly three values")
+        self.weights = np.array(weights, dtype=np.float32)
+
+    def score_pair(self, img1: np.ndarray, img2: np.ndarray) -> Tuple[float, float, float, float]:
+        try:
+            orb = compute_orb_similarity(img1, img2)
+            hist = compute_histogram_similarity(img1, img2)
+            ssim = compute_ssim_similarity(img1, img2)
+        except cv2.error as exc:  # pragma: no cover - defensive
+            raise ImageProcessingError(f"OpenCV failed while scoring images: {exc}") from exc
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ImageProcessingError(str(exc)) from exc
+        score = float(np.clip(np.dot(self.weights, np.array([orb, hist, ssim], dtype=np.float32)), 0.0, 1.0))
+        return score, orb, hist, ssim
+
+    def match(self, query: Path, candidates: Iterable[Path]) -> List[MatchResult]:
+        query_img = _load_image(query)
+        results: List[MatchResult] = []
+        for candidate in candidates:
+            candidate_img = _load_image(candidate)
+            score, orb, hist, ssim = self.score_pair(query_img, candidate_img)
+            results.append(MatchResult(candidate, score, orb, hist, ssim))
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results

--- a/fuzzy_image_matching/templates/index.html
+++ b/fuzzy_image_matching/templates/index.html
@@ -1,0 +1,354 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fuzzy Image Matcher</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", Tahoma, sans-serif;
+        background: #f5f5f5;
+        color: #1f2933;
+      }
+
+      body {
+        margin: 0;
+        padding: 2rem 1rem 4rem;
+        display: flex;
+        justify-content: center;
+        background: linear-gradient(135deg, #f0f4f8, #d9e2ec);
+        min-height: 100vh;
+      }
+
+      .container {
+        width: min(960px, 100%);
+        background: rgba(255, 255, 255, 0.92);
+        border-radius: 18px;
+        box-shadow: 0 18px 40px rgba(15, 35, 95, 0.12);
+        padding: 2.5rem;
+        backdrop-filter: blur(8px);
+      }
+
+      h1 {
+        margin-top: 0;
+        margin-bottom: 1.5rem;
+        font-size: clamp(2rem, 4vw, 2.8rem);
+        text-align: center;
+      }
+
+      form {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .form-row {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      label {
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: #334e68;
+      }
+
+      input[type="file"],
+      input[type="number"] {
+        width: 100%;
+        padding: 0.8rem 1rem;
+        border-radius: 12px;
+        border: 1px solid #cbd2d9;
+        background: #fff;
+        font-size: 1rem;
+        box-sizing: border-box;
+      }
+
+      input[type="number"] {
+        -moz-appearance: textfield;
+      }
+
+      input[type="number"]::-webkit-outer-spin-button,
+      input[type="number"]::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      .weights-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+      }
+
+      .submit-row {
+        display: flex;
+        justify-content: center;
+      }
+
+      button {
+        background: linear-gradient(135deg, #3b82f6, #2563eb);
+        color: #fff;
+        font-weight: 600;
+        font-size: 1rem;
+        border: none;
+        padding: 0.9rem 2.4rem;
+        border-radius: 999px;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 32px rgba(37, 99, 235, 0.3);
+      }
+
+      .messages {
+        display: grid;
+        gap: 0.75rem;
+        margin-top: 1rem;
+      }
+
+      .message {
+        padding: 0.9rem 1.2rem;
+        border-radius: 12px;
+        background: #fee2e2;
+        color: #b91c1c;
+        border: 1px solid rgba(248, 113, 113, 0.45);
+      }
+
+      .results {
+        margin-top: 3rem;
+        display: grid;
+        gap: 2rem;
+      }
+
+      .results h2 {
+        margin: 0;
+        font-size: 1.75rem;
+      }
+
+      .preview-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .preview-card {
+        background: #fff;
+        border-radius: 16px;
+        box-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+        padding: 1.25rem;
+        display: grid;
+        gap: 0.85rem;
+      }
+
+      .preview-card img {
+        width: 100%;
+        height: 200px;
+        object-fit: cover;
+        border-radius: 12px;
+        border: 1px solid #e2e8f0;
+      }
+
+      .no-preview {
+        display: grid;
+        place-items: center;
+        width: 100%;
+        height: 200px;
+        border-radius: 12px;
+        border: 1px dashed #cbd5f5;
+        background: rgba(226, 232, 240, 0.45);
+        color: #475569;
+        font-size: 0.95rem;
+        text-align: center;
+        padding: 0 1rem;
+      }
+
+      .score {
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: #1d4ed8;
+      }
+
+      .metrics {
+        font-size: 0.95rem;
+        color: #475569;
+        display: grid;
+        gap: 0.25rem;
+      }
+
+      .query-preview {
+        display: grid;
+        justify-items: center;
+        gap: 1rem;
+      }
+
+      .query-preview img {
+        width: min(320px, 100%);
+        border-radius: 16px;
+        border: 1px solid #cbd5f5;
+        box-shadow: 0 12px 26px rgba(59, 130, 246, 0.25);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          background: #0f172a;
+          color: #e2e8f0;
+        }
+
+        .container {
+          background: rgba(15, 23, 42, 0.85);
+          box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+        }
+
+        label {
+          color: #cbd5f5;
+        }
+
+        input[type="file"],
+        input[type="number"] {
+          background: rgba(15, 23, 42, 0.85);
+          border: 1px solid #334155;
+          color: inherit;
+        }
+
+        .preview-card {
+          background: rgba(15, 23, 42, 0.8);
+          border: 1px solid #1e293b;
+        }
+
+        .no-preview {
+          border-color: rgba(148, 163, 184, 0.45);
+          background: rgba(30, 41, 59, 0.55);
+          color: #cbd5f5;
+        }
+
+        .message {
+          background: rgba(239, 68, 68, 0.15);
+          border-color: rgba(239, 68, 68, 0.35);
+          color: #fca5a5;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>Fuzzy Image Matcher</h1>
+      <form method="post" enctype="multipart/form-data">
+        <div class="form-row">
+          <label for="query">Query image</label>
+          <input id="query" type="file" name="query" accept="image/*" required />
+        </div>
+        <div class="form-row">
+          <label for="candidates">Candidate images</label>
+          <input
+            id="candidates"
+            type="file"
+            name="candidates"
+            accept="image/*"
+            multiple
+            required
+          />
+        </div>
+        <div class="weights-grid">
+          <div class="form-row">
+            <label for="weight_orb">ORB weight</label>
+            <input
+              id="weight_orb"
+              type="number"
+              name="weight_orb"
+              step="0.05"
+              min="0"
+              value="{{ '%.2f'|format(weights[0]) }}"
+            />
+          </div>
+          <div class="form-row">
+            <label for="weight_hist">Histogram weight</label>
+            <input
+              id="weight_hist"
+              type="number"
+              name="weight_hist"
+              step="0.05"
+              min="0"
+              value="{{ '%.2f'|format(weights[1]) }}"
+            />
+          </div>
+          <div class="form-row">
+            <label for="weight_ssim">SSIM weight</label>
+            <input
+              id="weight_ssim"
+              type="number"
+              name="weight_ssim"
+              step="0.05"
+              min="0"
+              value="{{ '%.2f'|format(weights[2]) }}"
+            />
+          </div>
+          <div class="form-row">
+            <label for="top">Top results</label>
+            <input
+              id="top"
+              type="number"
+              name="top"
+              min="1"
+              value="{{ top }}"
+            />
+          </div>
+        </div>
+        <div class="submit-row">
+          <button type="submit">Compare images</button>
+        </div>
+      </form>
+
+      {% if errors %}
+        <div class="messages">
+          {% for message in errors %}
+            <div class="message">{{ message }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      {% if results is not none %}
+        <section class="results">
+          <div class="query-preview">
+            <h2>Query preview</h2>
+            {% if query_preview %}
+              <img src="{{ query_preview }}" alt="Uploaded query preview" />
+            {% else %}
+              <p>No preview available.</p>
+            {% endif %}
+          </div>
+
+          {% if results %}
+            <div>
+              <h2>Top matches</h2>
+              <div class="preview-grid">
+                {% for item in results %}
+                  <article class="preview-card">
+                    {% if item.preview %}
+                      <img src="{{ item.preview }}" alt="Preview of {{ item.name }}" />
+                    {% else %}
+                      <div class="no-preview">Preview unavailable</div>
+                    {% endif %}
+                    <div>
+                      <div class="score">Score: {{ '%.3f'|format(item.score) }}</div>
+                      <div class="metrics">
+                        <span>ORB: {{ '%.3f'|format(item.orb) }}</span>
+                        <span>Histogram: {{ '%.3f'|format(item.histogram) }}</span>
+                        <span>SSIM: {{ '%.3f'|format(item.ssim) }}</span>
+                      </div>
+                    </div>
+                    <footer>{{ item.name }}</footer>
+                  </article>
+                {% endfor %}
+              </div>
+            </div>
+          {% else %}
+            <p>No candidate images could be processed.</p>
+          {% endif %}
+        </section>
+      {% endif %}
+    </main>
+  </body>
+</html>

--- a/fuzzy_image_matching/webapp.py
+++ b/fuzzy_image_matching/webapp.py
@@ -1,0 +1,177 @@
+"""Simple web UI for fuzzy image matching."""
+
+from __future__ import annotations
+
+import base64
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+from flask import Flask, render_template, request
+
+from .matching import FuzzyImageMatcher, ImageProcessingError
+
+
+DEFAULT_WEIGHTS: Tuple[float, float, float] = (0.4, 0.3, 0.3)
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(
+        __name__,
+        template_folder="templates",
+    )
+    # Limit uploads to 16 MiB to prevent extremely large files.
+    app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024
+
+    @app.route("/", methods=["GET", "POST"])
+    def index():
+        weights = list(DEFAULT_WEIGHTS)
+        errors: List[str] = []
+        results = None
+        query_preview = None
+        query_image: np.ndarray | None = None
+        top_value = 5
+
+        if request.method == "POST":
+            # Parse weights, keeping the provided values even if invalid to display back to the user.
+            weight_fields = [
+                ("weight_orb", DEFAULT_WEIGHTS[0], "ORB weight"),
+                ("weight_hist", DEFAULT_WEIGHTS[1], "Histogram weight"),
+                ("weight_ssim", DEFAULT_WEIGHTS[2], "SSIM weight"),
+            ]
+            parsed_weights: List[float] = []
+            for idx, (field, default, label) in enumerate(weight_fields):
+                value_raw = request.form.get(field, str(default)).strip()
+                try:
+                    value = float(value_raw)
+                except (TypeError, ValueError):
+                    errors.append(f"{label} must be a number.")
+                    value = weights[idx]
+                parsed_weights.append(value)
+            weights = parsed_weights
+
+            if sum(weights) <= 0:
+                errors.append("At least one weight must be greater than zero.")
+
+            top_raw = request.form.get("top", str(top_value)).strip()
+            try:
+                top_value = int(top_raw)
+                if top_value <= 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                errors.append("Top results must be a positive integer.")
+                top_value = 5
+
+            query_file = request.files.get("query")
+            if not query_file or not query_file.filename:
+                errors.append("Please upload a query image.")
+            else:
+                try:
+                    query_image = _file_to_image(query_file)
+                    query_preview = _image_to_data_url(query_image)
+                except ValueError:
+                    errors.append("Could not read the query image. Please upload a valid image file.")
+
+            candidate_files = [
+                f for f in request.files.getlist("candidates") if f and f.filename
+            ]
+            if not candidate_files:
+                errors.append("Please upload at least one candidate image.")
+
+            if not errors and query_image is not None:
+                try:
+                    matcher = FuzzyImageMatcher(weights=weights)
+                except ValueError as exc:
+                    errors.append(str(exc))
+                    matcher = None
+
+                if matcher is not None:
+                    scored_results = []
+                    for storage in candidate_files:
+                        try:
+                            candidate_image = _file_to_image(storage)
+                        except ValueError:
+                            errors.append(
+                                f"Could not read candidate image: {storage.filename or 'Unnamed file'}."
+                            )
+                            continue
+
+                        try:
+                            score, orb, hist, ssim = matcher.score_pair(query_image, candidate_image)
+                        except ImageProcessingError as exc:
+                            errors.append(
+                                f"Failed to compare {storage.filename or 'candidate image'}: {exc}"
+                            )
+                            continue
+                        except Exception as exc:  # pragma: no cover - defensive
+                            app.logger.exception("Unexpected error while scoring image")
+                            errors.append(
+                                f"An unexpected error occurred while scoring {storage.filename or 'a candidate image'}."
+                            )
+                            continue
+
+                        try:
+                            preview = _image_to_data_url(candidate_image)
+                        except ValueError:
+                            errors.append(
+                                f"Could not generate preview for {storage.filename or 'a candidate image'}."
+                            )
+                            preview = None
+
+                        scored_results.append(
+                            {
+                                "name": storage.filename or "Candidate",
+                                "score": score,
+                                "orb": orb,
+                                "histogram": hist,
+                                "ssim": ssim,
+                                "preview": preview,
+                            }
+                        )
+
+                    if scored_results:
+                        scored_results.sort(key=lambda item: item["score"], reverse=True)
+                        results = scored_results[: top_value if top_value > 0 else len(scored_results)]
+                    else:
+                        results = []
+
+        return render_template(
+            "index.html",
+            weights=weights,
+            top=top_value,
+            results=results,
+            errors=errors,
+            query_preview=query_preview,
+        )
+
+    return app
+
+
+def _file_to_image(storage) -> np.ndarray:
+    """Decode an uploaded file into a BGR OpenCV image."""
+    storage.stream.seek(0)
+    file_bytes = storage.read()
+    if not file_bytes:
+        raise ValueError("Empty upload")
+    array = np.frombuffer(file_bytes, dtype=np.uint8)
+    image = cv2.imdecode(array, cv2.IMREAD_COLOR)
+    if image is None:
+        raise ValueError("Invalid image data")
+    return image
+
+
+def _image_to_data_url(image: np.ndarray) -> str:
+    """Convert an image array to a base64 data URL for inline display."""
+    success, buffer = cv2.imencode(".jpg", image)
+    if not success:
+        raise ValueError("Unable to encode image")
+    encoded = base64.b64encode(buffer.tobytes()).decode("utf-8")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+app = create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add an ImageProcessingError to guard OpenCV failures and ensure histogram/SSIM helpers normalise incoming images
- harden the CLI and Flask UI with user-facing validation, weight checks, and graceful handling of preview generation
- show a placeholder when previews cannot be generated so the page still renders results

## Testing
- python -m compileall fuzzy_image_matching

------
https://chatgpt.com/codex/tasks/task_e_68db86319280832c8251207d77583df7