### PR TITLE
Revamp web UI for smoother fuzzy matching results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# Fuzzy-image-matching
+# Fuzzy Image Matching
+
+A Python utility for fuzzy image matching using a combination of ORB feature matching, color histogram comparison, and Structural Similarity Index (SSIM).
+
+## Features
+
+- Compare a query image against one or more candidate images or directories.
+- Combines multiple similarity metrics with configurable weights.
+- Command line interface for quick usage.
+- Minimal web UI for running comparisons without the terminal.
+
+## Requirements
+
+- Python 3.9+
+- `opencv-python`
+- `scikit-image`
+- `numpy`
+
+Install dependencies using pip:
+
+```bash
+pip install opencv-python scikit-image numpy
+```
+
+For the optional web interface install Flask as well:
+
+```bash
+pip install flask
+```
+
+## Usage
+
+Run the matcher from the project root:
+
+```bash
+python -m fuzzy_image_matching.cli <query_image> <candidate1> [<candidate2> ...] [options]
+```
+
+You can pass directories as candidate arguments to compare against all files in the directory.
+
+### Options
+
+- `--weights ORB HIST SSIM`: Custom weights for ORB, histogram, and SSIM scores. Defaults to `0.4 0.3 0.3`.
+- `--top N`: Limit the output to the top N matches (defaults to 5).
+
+### Example
+
+```bash
+python -m fuzzy_image_matching.cli ./examples/query.jpg ./examples/candidates --top 3
+```
+
+This will output the top three matches and show the individual metric contributions.
+
+## Web UI
+
+Launch the browser-based interface with Flask:
+
+```bash
+python -m flask --app fuzzy_image_matching.webapp run
+```
+
+Then open <http://localhost:5000> to upload a query image and one or more candidate images. You can adjust the metric weights and number of results directly in the interface, and the page will display previews and detailed scores for the best matches.
+
+## Project Structure
+
+```
+fuzzy_image_matching/
+├── __init__.py
+├── cli.py
+└── matching.py
+```
+
+## License
+
+MIT

--- a/fuzzy_image_matching/__init__.py
+++ b/fuzzy_image_matching/__init__.py
@@ -1,0 +1,19 @@
+"""Fuzzy image matching package."""
+
+from .matching import (
+    FuzzyImageMatcher,
+    ImageProcessingError,
+    MatchResult,
+    compute_histogram_similarity,
+    compute_orb_similarity,
+    compute_ssim_similarity,
+)
+
+__all__ = [
+    "FuzzyImageMatcher",
+    "ImageProcessingError",
+    "MatchResult",
+    "compute_histogram_similarity",
+    "compute_orb_similarity",
+    "compute_ssim_similarity",
+]

--- a/fuzzy_image_matching/cli.py
+++ b/fuzzy_image_matching/cli.py
@@ -1,0 +1,79 @@
+"""Command line interface for fuzzy image matching."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from .matching import FuzzyImageMatcher, ImageProcessingError
+
+
+class ExistingPath(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        path = Path(values)
+        if not path.exists():
+            parser.error(f"Path does not exist: {path}")
+        setattr(namespace, self.dest, path)
+
+
+def _iter_candidate_paths(path: Path) -> Iterable[Path]:
+    if path.is_dir():
+        yield from sorted(p for p in path.iterdir() if p.is_file())
+    else:
+        yield path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fuzzy image matcher")
+    parser.add_argument("query", action=ExistingPath, help="Query image")
+    parser.add_argument(
+        "candidates",
+        nargs="+",
+        help="Candidate image files or directories",
+    )
+    parser.add_argument(
+        "--weights",
+        type=float,
+        nargs=3,
+        metavar=("ORB", "HIST", "SSIM"),
+        help="Weights for similarity metrics (default: 0.4 0.3 0.3)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="Number of top matches to show",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    matcher = FuzzyImageMatcher(weights=args.weights)
+    candidate_files: list[Path] = []
+    for candidate in args.candidates:
+        candidate_files.extend(_iter_candidate_paths(Path(candidate)))
+
+    try:
+        results = matcher.match(args.query, candidate_files)
+    except (FileNotFoundError, ImageProcessingError) as exc:
+        parser.error(str(exc))
+
+    top_n = args.top if args.top > 0 else len(results)
+
+    print(f"Query image: {args.query}")
+    print("Candidates scored (higher is better):")
+    for result in results[:top_n]:
+        print(
+            f"  {result.candidate}: score={result.score:.3f} "
+            f"(ORB={result.orb:.3f}, HIST={result.histogram:.3f}, SSIM={result.ssim:.3f})"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/fuzzy_image_matching/matching.py
+++ b/fuzzy_image_matching/matching.py
@@ -1,0 +1,136 @@
+"""Fuzzy image matching utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+import cv2
+import numpy as np
+from skimage.metrics import structural_similarity
+
+
+class ImageProcessingError(Exception):
+    """Raised when an image cannot be processed for matching."""
+
+
+def _load_image(path: Path) -> np.ndarray:
+    """Load an image from disk and ensure it is in BGR format."""
+    image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if image is None:
+        raise FileNotFoundError(f"Could not read image at {path}")
+    return _ensure_bgr(image)
+
+
+def _ensure_gray(image: np.ndarray) -> np.ndarray:
+    if len(image.shape) == 3:
+        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    return image
+
+
+def _ensure_bgr(image: np.ndarray) -> np.ndarray:
+    """Convert grayscale or BGRA images to BGR."""
+    if image.ndim == 2:
+        return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+    if image.shape[2] == 4:
+        return cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+    return image
+
+
+def compute_orb_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute similarity score based on ORB feature matching.
+
+    Returns a score between 0 and 1.
+    """
+    orb = cv2.ORB_create()
+    keypoints1, descriptors1 = orb.detectAndCompute(img1, None)
+    keypoints2, descriptors2 = orb.detectAndCompute(img2, None)
+
+    if descriptors1 is None or descriptors2 is None or len(keypoints1) == 0:
+        return 0.0
+
+    matcher = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+    matches = matcher.match(descriptors1, descriptors2)
+    if not matches:
+        return 0.0
+
+    distances = np.array([m.distance for m in matches], dtype=np.float32)
+    score = np.exp(-distances.mean() / 50.0)
+    return float(np.clip(score, 0.0, 1.0))
+
+
+def compute_histogram_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute similarity using color histograms."""
+    img1_bgr = _ensure_bgr(img1)
+    img2_bgr = _ensure_bgr(img2)
+
+    img1_hsv = cv2.cvtColor(img1_bgr, cv2.COLOR_BGR2HSV)
+    img2_hsv = cv2.cvtColor(img2_bgr, cv2.COLOR_BGR2HSV)
+
+    hist_size = [8, 8, 8]
+    ranges = [0, 180, 0, 256, 0, 256]
+    channels = [0, 1, 2]
+
+    hist1 = cv2.calcHist([img1_hsv], channels, None, hist_size, ranges)
+    hist2 = cv2.calcHist([img2_hsv], channels, None, hist_size, ranges)
+
+    cv2.normalize(hist1, hist1)
+    cv2.normalize(hist2, hist2)
+
+    score = cv2.compareHist(hist1, hist2, cv2.HISTCMP_CORREL)
+    score = (score + 1) / 2  # convert to 0-1
+    return float(np.clip(score, 0.0, 1.0))
+
+
+def compute_ssim_similarity(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute Structural Similarity Index (SSIM)."""
+    gray1 = _ensure_gray(img1)
+    gray2 = _ensure_gray(img2)
+    if gray1.size == 0 or gray2.size == 0:
+        raise ImageProcessingError("Cannot compare empty images")
+    gray2_resized = cv2.resize(gray2, (gray1.shape[1], gray1.shape[0]))
+    score, _ = structural_similarity(gray1, gray2_resized, full=True)
+    return float(np.clip(score, 0.0, 1.0))
+
+
+@dataclass
+class MatchResult:
+    candidate: Path
+    score: float
+    orb: float
+    histogram: float
+    ssim: float
+
+
+class FuzzyImageMatcher:
+    """Match a query image against a collection of candidate images."""
+
+    def __init__(self, weights: Sequence[float] | None = None) -> None:
+        if weights is None:
+            weights = (0.4, 0.3, 0.3)
+        if len(weights) != 3:
+            raise ValueError("weights must contain exactly three values")
+        self.weights = np.array(weights, dtype=np.float32)
+
+    def score_pair(self, img1: np.ndarray, img2: np.ndarray) -> Tuple[float, float, float, float]:
+        try:
+            orb = compute_orb_similarity(img1, img2)
+            hist = compute_histogram_similarity(img1, img2)
+            ssim = compute_ssim_similarity(img1, img2)
+        except cv2.error as exc:  # pragma: no cover - defensive
+            raise ImageProcessingError(f"OpenCV failed while scoring images: {exc}") from exc
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ImageProcessingError(str(exc)) from exc
+        score = float(np.clip(np.dot(self.weights, np.array([orb, hist, ssim], dtype=np.float32)), 0.0, 1.0))
+        return score, orb, hist, ssim
+
+    def match(self, query: Path, candidates: Iterable[Path]) -> List[MatchResult]:
+        query_img = _load_image(query)
+        results: List[MatchResult] = []
+        for candidate in candidates:
+            candidate_img = _load_image(candidate)
+            score, orb, hist, ssim = self.score_pair(query_img, candidate_img)
+            results.append(MatchResult(candidate, score, orb, hist, ssim))
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results

--- a/fuzzy_image_matching/templates/index.html
+++ b/fuzzy_image_matching/templates/index.html
@@ -1,0 +1,712 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fuzzy Image Matcher</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        padding: 2rem;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+        background: radial-gradient(circle at top, #1e293b 0%, #0f172a 55%, #020617 100%);
+        color: #f8fafc;
+      }
+
+      main {
+        width: min(1120px, 100%);
+        display: grid;
+        gap: 2rem;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 5vw, 3rem);
+        font-weight: 700;
+      }
+
+      header p {
+        margin: 0.75rem 0 0;
+        color: rgba(226, 232, 240, 0.72);
+        max-width: 640px;
+        line-height: 1.6;
+      }
+
+      .layout {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        align-items: flex-start;
+      }
+
+      .panel {
+        flex: 1 1 320px;
+        background: rgba(15, 23, 42, 0.78);
+        border: 1px solid rgba(148, 163, 184, 0.1);
+        box-shadow: 0 22px 45px rgba(8, 11, 26, 0.4);
+        border-radius: 22px;
+        padding: 1.75rem;
+        backdrop-filter: blur(12px);
+      }
+
+      form {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .form-grid {
+        display: grid;
+        gap: 1.1rem;
+      }
+
+      .field label {
+        display: block;
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: rgba(241, 245, 249, 0.86);
+        margin-bottom: 0.4rem;
+      }
+
+      .field input[type="file"],
+      .field input[type="number"] {
+        width: 100%;
+        border-radius: 14px;
+        padding: 0.85rem 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.55);
+        color: inherit;
+        font-size: 1rem;
+      }
+
+      .field input[type="file"] {
+        padding: 0.65rem 1rem;
+      }
+
+      .field input[type="number"] {
+        -moz-appearance: textfield;
+      }
+
+      .field input[type="number"]::-webkit-outer-spin-button,
+      .field input[type="number"]::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      .split {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 1rem;
+      }
+
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      button[type="submit"] {
+        appearance: none;
+        border: none;
+        border-radius: 999px;
+        background: linear-gradient(135deg, #60a5fa, #2563eb);
+        padding: 0.85rem 1.9rem;
+        font-weight: 600;
+        font-size: 1rem;
+        color: #fff;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        box-shadow: 0 18px 38px rgba(37, 99, 235, 0.35);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      button[type="submit"]:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 24px 46px rgba(37, 99, 235, 0.4);
+      }
+
+      button[type="submit"]:disabled {
+        cursor: progress;
+        opacity: 0.7;
+        box-shadow: none;
+      }
+
+      .btn-label {
+        white-space: nowrap;
+      }
+
+      .btn-spinner {
+        width: 1rem;
+        height: 1rem;
+        border-radius: 999px;
+        border: 2px solid rgba(255, 255, 255, 0.45);
+        border-top-color: #fff;
+        animation: spin 0.9s linear infinite;
+        display: none;
+      }
+
+      button[aria-busy="true"] .btn-spinner {
+        display: inline-block;
+      }
+
+      button[aria-busy="true"] .btn-label {
+        opacity: 0.7;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .messages {
+        display: grid;
+        gap: 0.75rem;
+        margin-bottom: 1.25rem;
+      }
+
+      .message {
+        padding: 0.8rem 1rem;
+        border-radius: 12px;
+        background: rgba(248, 113, 113, 0.16);
+        border: 1px solid rgba(248, 113, 113, 0.35);
+        color: #fecaca;
+        font-size: 0.95rem;
+      }
+
+      .results-panel h2 {
+        margin: 0;
+        font-size: 1.4rem;
+      }
+
+      .results-intro {
+        margin: 0.35rem 0 1.25rem;
+        color: rgba(226, 232, 240, 0.72);
+        font-size: 0.95rem;
+        line-height: 1.6;
+      }
+
+      .query-preview {
+        margin-bottom: 1.4rem;
+        display: none;
+      }
+
+      .query-preview[aria-hidden="false"] {
+        display: block;
+      }
+
+      .query-preview img {
+        width: 100%;
+        max-width: 320px;
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        box-shadow: 0 16px 32px rgba(8, 11, 26, 0.55);
+      }
+
+      .results-list {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .result-card {
+        display: grid;
+        gap: 0.85rem;
+        background: rgba(15, 23, 42, 0.62);
+        border: 1px solid rgba(148, 163, 184, 0.16);
+        border-radius: 18px;
+        padding: 1rem;
+      }
+
+      .result-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      .result-name {
+        font-weight: 600;
+        font-size: 1.05rem;
+      }
+
+      .result-score {
+        font-weight: 600;
+        color: #60a5fa;
+        font-size: 1.05rem;
+      }
+
+      .preview-wrapper {
+        position: relative;
+      }
+
+      .result-preview {
+        width: 100%;
+        max-height: 220px;
+        border-radius: 14px;
+        object-fit: cover;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .no-preview {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 180px;
+        border-radius: 14px;
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        color: rgba(226, 232, 240, 0.7);
+        background: rgba(15, 23, 42, 0.35);
+        font-size: 0.95rem;
+        padding: 1.2rem;
+        text-align: center;
+      }
+
+      .no-preview[hidden],
+      .result-preview[hidden] {
+        display: none;
+      }
+
+      .metric-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        color: rgba(226, 232, 240, 0.8);
+        font-size: 0.92rem;
+      }
+
+      .metric {
+        background: rgba(37, 99, 235, 0.18);
+        border-radius: 999px;
+        padding: 0.35rem 0.65rem;
+      }
+
+      .empty-state {
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.38);
+        padding: 1.25rem;
+        border-radius: 16px;
+        text-align: center;
+        color: rgba(226, 232, 240, 0.7);
+        font-size: 0.95rem;
+      }
+
+      .helper-text {
+        color: rgba(226, 232, 240, 0.65);
+        font-size: 0.88rem;
+      }
+
+      noscript {
+        display: block;
+        margin-top: 1.5rem;
+        padding: 0.85rem 1rem;
+        background: rgba(248, 191, 50, 0.18);
+        border: 1px solid rgba(248, 191, 50, 0.35);
+        border-radius: 12px;
+        color: #fde68a;
+        font-size: 0.9rem;
+      }
+
+      @media (max-width: 960px) {
+        body {
+          padding: 1.5rem;
+        }
+
+        .layout {
+          flex-direction: column;
+        }
+
+        .actions {
+          justify-content: stretch;
+        }
+
+        button[type="submit"] {
+          width: 100%;
+          justify-content: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Fuzzy Image Matcher</h1>
+        <p>
+          Upload a query image and one or more candidates to compare them using ORB
+          features, colour histograms, and SSIM. Adjust the weights to emphasise the
+          metrics that matter most for your search.
+        </p>
+      </header>
+
+      <div class="layout">
+        <section class="panel" aria-label="Upload images">
+          <form id="compare-form" method="post" enctype="multipart/form-data">
+            <div class="form-grid">
+              <div class="field">
+                <label for="query">Query image</label>
+                <input id="query" type="file" name="query" accept="image/*" required />
+              </div>
+
+              <div class="field">
+                <label for="candidates">Candidate images</label>
+                <input
+                  id="candidates"
+                  type="file"
+                  name="candidates"
+                  accept="image/*"
+                  multiple
+                  required
+                />
+                <p class="helper-text">Select one or more files. JPEG, PNG, and WebP are supported.</p>
+              </div>
+
+              <div class="split">
+                <div class="field">
+                  <label for="weight_orb">ORB weight</label>
+                  <input
+                    id="weight_orb"
+                    type="number"
+                    name="weight_orb"
+                    step="0.05"
+                    min="0"
+                    value="{{ '%.2f'|format(weights[0]) }}"
+                    data-weight-index="0"
+                  />
+                </div>
+                <div class="field">
+                  <label for="weight_hist">Histogram weight</label>
+                  <input
+                    id="weight_hist"
+                    type="number"
+                    name="weight_hist"
+                    step="0.05"
+                    min="0"
+                    value="{{ '%.2f'|format(weights[1]) }}"
+                    data-weight-index="1"
+                  />
+                </div>
+                <div class="field">
+                  <label for="weight_ssim">SSIM weight</label>
+                  <input
+                    id="weight_ssim"
+                    type="number"
+                    name="weight_ssim"
+                    step="0.05"
+                    min="0"
+                    value="{{ '%.2f'|format(weights[2]) }}"
+                    data-weight-index="2"
+                  />
+                </div>
+                <div class="field">
+                  <label for="top">Top results</label>
+                  <input id="top" type="number" name="top" min="1" value="{{ top }}" />
+                </div>
+              </div>
+            </div>
+
+            <div class="actions">
+              <button id="submit-button" type="submit" aria-busy="false">
+                <span class="btn-label">Compare images</span>
+                <span class="btn-spinner" aria-hidden="true"></span>
+              </button>
+            </div>
+          </form>
+          <noscript>提交表单后页面会重新加载以显示结果。</noscript>
+        </section>
+
+        <section class="panel results-panel" aria-live="polite">
+          <h2>Results</h2>
+          <p class="results-intro">
+            Matches appear here after the comparison completes. You can keep the page open
+            and try different weight combinations without losing the previous results.
+          </p>
+
+          <div id="messages" class="messages" role="alert">
+            {% if errors %}
+              {% for message in errors %}
+                <div class="message">{{ message }}</div>
+              {% endfor %}
+            {% endif %}
+          </div>
+
+          <div id="query-preview" class="query-preview" aria-hidden="{{ 'false' if query_preview else 'true' }}">
+            <h3>Query preview</h3>
+            {% if query_preview %}
+              <img id="query-preview-img" src="{{ query_preview }}" alt="Preview of the uploaded query image" />
+            {% else %}
+              <img id="query-preview-img" alt="" hidden />
+            {% endif %}
+          </div>
+
+          <div
+            id="results"
+            class="results-list"
+            data-placeholder="{{ placeholder_text }}"
+            aria-live="polite"
+          >
+            {% if submitted %}
+              {% if results %}
+                {% for item in results %}
+                  <article class="result-card">
+                    <div class="result-header">
+                      <span class="result-name">{{ item.name }}</span>
+                      <span class="result-score">Score {{ '%.3f'|format(item.score) }}</span>
+                    </div>
+                    <div class="preview-wrapper">
+                      {% if item.preview %}
+                        <img
+                          class="result-preview"
+                          src="{{ item.preview }}"
+                          alt="Preview of {{ item.name }}"
+                        />
+                      {% else %}
+                        <div class="no-preview">Preview unavailable</div>
+                      {% endif %}
+                    </div>
+                    <div class="metric-list">
+                      <span class="metric">ORB {{ '%.3f'|format(item.orb) }}</span>
+                      <span class="metric">Histogram {{ '%.3f'|format(item.histogram) }}</span>
+                      <span class="metric">SSIM {{ '%.3f'|format(item.ssim) }}</span>
+                    </div>
+                  </article>
+                {% endfor %}
+              {% else %}
+                <p class="empty-state">No matches were returned for this comparison.</p>
+              {% endif %}
+            {% else %}
+              <p class="empty-state" id="results-placeholder">{{ placeholder_text }}</p>
+            {% endif %}
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <template id="result-card-template">
+      <article class="result-card">
+        <div class="result-header">
+          <span class="result-name"></span>
+          <span class="result-score"></span>
+        </div>
+        <div class="preview-wrapper">
+          <img class="result-preview" alt="" />
+          <div class="no-preview" hidden>Preview unavailable</div>
+        </div>
+        <div class="metric-list">
+          <span class="metric metric-orb"></span>
+          <span class="metric metric-hist"></span>
+          <span class="metric metric-ssim"></span>
+        </div>
+      </article>
+    </template>
+
+    <script>
+      const form = document.getElementById("compare-form");
+      const submitButton = document.getElementById("submit-button");
+      const messages = document.getElementById("messages");
+      const resultsList = document.getElementById("results");
+      const queryPreview = document.getElementById("query-preview");
+      const queryPreviewImage = document.getElementById("query-preview-img");
+      const weightInputs = Array.from(document.querySelectorAll("[data-weight-index]"));
+      const topInput = document.getElementById("top");
+      const defaultPlaceholder = resultsList?.dataset?.placeholder || "";
+      const resultTemplate = document.getElementById("result-card-template");
+      const initialPayload = {{ initial_payload | tojson }};
+      const initialWeights = weightInputs.map((input) => Number.parseFloat(input.value) || 0);
+      const initialTop = Number.parseInt(topInput?.value || "5", 10) || 5;
+
+      function setBusy(isBusy) {
+        if (!submitButton) return;
+        submitButton.disabled = isBusy;
+        submitButton.setAttribute("aria-busy", isBusy ? "true" : "false");
+      }
+
+      function showMessages(list) {
+        if (!messages) return;
+        messages.innerHTML = "";
+        if (!list || !list.length) {
+          return;
+        }
+        list.forEach((message) => {
+          const div = document.createElement("div");
+          div.className = "message";
+          div.textContent = message;
+          messages.appendChild(div);
+        });
+      }
+
+      function updateWeights(weights) {
+        if (!Array.isArray(weights) || weightInputs.length === 0) {
+          return;
+        }
+        weightInputs.forEach((input, index) => {
+          if (!input) return;
+          const value = Number.parseFloat(weights[index]);
+          if (!Number.isFinite(value)) return;
+          input.value = value.toFixed(2);
+        });
+      }
+
+      function updateTop(topValue) {
+        if (!topInput) return;
+        const value = Number.parseInt(topValue, 10);
+        if (!Number.isFinite(value) || value <= 0) {
+          return;
+        }
+        topInput.value = String(value);
+      }
+
+      function updateQueryPreview(src) {
+        if (!queryPreview || !queryPreviewImage) return;
+        if (src) {
+          queryPreview.setAttribute("aria-hidden", "false");
+          queryPreviewImage.removeAttribute("hidden");
+          queryPreviewImage.src = src;
+          queryPreviewImage.alt = "Preview of the uploaded query image";
+        } else {
+          queryPreview.setAttribute("aria-hidden", "true");
+          queryPreviewImage.setAttribute("hidden", "");
+          queryPreviewImage.removeAttribute("src");
+          queryPreviewImage.alt = "";
+        }
+      }
+
+      function renderResults(results) {
+        if (!resultsList) return;
+        resultsList.innerHTML = "";
+        if (!results || results.length === 0) {
+          if (defaultPlaceholder) {
+            const empty = document.createElement("p");
+            empty.className = "empty-state";
+            empty.textContent = "No matches were returned for this comparison.";
+            resultsList.appendChild(empty);
+          }
+          return;
+        }
+
+        results.forEach((item) => {
+          const fragment = resultTemplate.content.cloneNode(true);
+          const card = fragment.querySelector(".result-card");
+          const name = fragment.querySelector(".result-name");
+          const score = fragment.querySelector(".result-score");
+          const orbMetric = fragment.querySelector(".metric-orb");
+          const histMetric = fragment.querySelector(".metric-hist");
+          const ssimMetric = fragment.querySelector(".metric-ssim");
+          const preview = fragment.querySelector(".result-preview");
+          const fallback = fragment.querySelector(".no-preview");
+
+          if (name) name.textContent = item.name || "Candidate";
+          if (score) score.textContent = `Score ${Number.parseFloat(item.score || 0).toFixed(3)}`;
+          if (orbMetric) orbMetric.textContent = `ORB ${Number.parseFloat(item.orb || 0).toFixed(3)}`;
+          if (histMetric) {
+            histMetric.textContent = `Histogram ${Number.parseFloat(item.histogram || item.hist || 0).toFixed(3)}`;
+          }
+          if (ssimMetric) ssimMetric.textContent = `SSIM ${Number.parseFloat(item.ssim || 0).toFixed(3)}`;
+
+          if (item.preview && preview) {
+            preview.hidden = false;
+            preview.src = item.preview;
+            preview.alt = `Preview of ${item.name || "candidate image"}`;
+            if (fallback) fallback.hidden = true;
+          } else {
+            if (preview) {
+              preview.hidden = true;
+              preview.removeAttribute("src");
+            }
+            if (fallback) fallback.hidden = false;
+          }
+
+          resultsList.appendChild(fragment);
+        });
+      }
+
+      function applyPayload(payload, { fromServer = false } = {}) {
+        if (!payload) return;
+        const errors = Array.isArray(payload.errors) ? payload.errors : [];
+        showMessages(errors);
+        updateWeights(payload.weights || initialWeights);
+        updateTop(payload.top ?? initialTop);
+        updateQueryPreview(payload.query_preview);
+
+        const shouldRenderResults =
+          (payload.submitted && errors.length === 0) ||
+          (Array.isArray(payload.results) && payload.results.length > 0) ||
+          (fromServer && payload.submitted);
+
+        if (shouldRenderResults) {
+          renderResults(payload.results || []);
+        } else if (fromServer && !payload.submitted) {
+          if (resultsList && defaultPlaceholder) {
+            resultsList.innerHTML = "";
+            const empty = document.createElement("p");
+            empty.className = "empty-state";
+            empty.textContent = defaultPlaceholder;
+            resultsList.appendChild(empty);
+          }
+        } else if (errors.length > 0 && !fromServer) {
+          // Preserve previous successful results on validation errors.
+        }
+      }
+
+      async function handleSubmit(event) {
+        event.preventDefault();
+        if (!form) return;
+        const formData = new FormData(form);
+        setBusy(true);
+        showMessages([]);
+        if (resultsList && defaultPlaceholder) {
+          resultsList.innerHTML = "";
+          const pending = document.createElement("p");
+          pending.className = "empty-state";
+          pending.textContent = "Comparing images…";
+          resultsList.appendChild(pending);
+        }
+
+        try {
+          const response = await fetch(form.action || window.location.pathname, {
+            method: "POST",
+            body: formData,
+            headers: {
+              Accept: "application/json",
+            },
+          });
+
+          const data = await response.json().catch(() => null);
+          if (data) {
+            applyPayload(data);
+          }
+
+          if (!response.ok && (!data || !(data.errors && data.errors.length))) {
+            showMessages(["The comparison failed. Please try again."]);
+          }
+        } catch (error) {
+          showMessages(["Could not reach the server. Check your connection and try again."]);
+        } finally {
+          setBusy(false);
+        }
+      }
+
+      if (form) {
+        form.addEventListener("submit", handleSubmit);
+      }
+
+      window.addEventListener("DOMContentLoaded", () => {
+        if (initialPayload) {
+          applyPayload(initialPayload, { fromServer: true });
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/fuzzy_image_matching/webapp.py
+++ b/fuzzy_image_matching/webapp.py
@@ -1,0 +1,194 @@
+"""Simple web UI for fuzzy image matching."""
+
+from __future__ import annotations
+
+import base64
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+from flask import Flask, jsonify, render_template, request
+
+from .matching import FuzzyImageMatcher, ImageProcessingError
+
+
+DEFAULT_WEIGHTS: Tuple[float, float, float] = (0.4, 0.3, 0.3)
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(
+        __name__,
+        template_folder="templates",
+    )
+    # Limit uploads to 16 MiB to prevent extremely large files.
+    app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024
+
+    @app.route("/", methods=["GET", "POST"])
+    def index():
+        weights = list(DEFAULT_WEIGHTS)
+        errors: List[str] = []
+        results: List[dict] | None = None
+        query_preview = None
+        query_image: np.ndarray | None = None
+        top_value = 5
+
+        if request.method == "POST":
+            # Parse weights, keeping the provided values even if invalid to display back to the user.
+            weight_fields = [
+                ("weight_orb", DEFAULT_WEIGHTS[0], "ORB weight"),
+                ("weight_hist", DEFAULT_WEIGHTS[1], "Histogram weight"),
+                ("weight_ssim", DEFAULT_WEIGHTS[2], "SSIM weight"),
+            ]
+            parsed_weights: List[float] = []
+            for idx, (field, default, label) in enumerate(weight_fields):
+                value_raw = request.form.get(field, str(default)).strip()
+                try:
+                    value = float(value_raw)
+                except (TypeError, ValueError):
+                    errors.append(f"{label} must be a number.")
+                    value = weights[idx]
+                parsed_weights.append(value)
+            weights = parsed_weights
+
+            if sum(weights) <= 0:
+                errors.append("At least one weight must be greater than zero.")
+
+            top_raw = request.form.get("top", str(top_value)).strip()
+            try:
+                top_value = int(top_raw)
+                if top_value <= 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                errors.append("Top results must be a positive integer.")
+                top_value = 5
+
+            query_file = request.files.get("query")
+            if not query_file or not query_file.filename:
+                errors.append("Please upload a query image.")
+            else:
+                try:
+                    query_image = _file_to_image(query_file)
+                    query_preview = _image_to_data_url(query_image)
+                except ValueError:
+                    errors.append("Could not read the query image. Please upload a valid image file.")
+
+            candidate_files = [
+                f for f in request.files.getlist("candidates") if f and f.filename
+            ]
+            if not candidate_files:
+                errors.append("Please upload at least one candidate image.")
+
+            if not errors and query_image is not None:
+                try:
+                    matcher = FuzzyImageMatcher(weights=weights)
+                except ValueError as exc:
+                    errors.append(str(exc))
+                    matcher = None
+
+                if matcher is not None:
+                    scored_results = []
+                    for storage in candidate_files:
+                        try:
+                            candidate_image = _file_to_image(storage)
+                        except ValueError:
+                            errors.append(
+                                f"Could not read candidate image: {storage.filename or 'Unnamed file'}."
+                            )
+                            continue
+
+                        try:
+                            score, orb, hist, ssim = matcher.score_pair(query_image, candidate_image)
+                        except ImageProcessingError as exc:
+                            errors.append(
+                                f"Failed to compare {storage.filename or 'candidate image'}: {exc}"
+                            )
+                            continue
+                        except Exception as exc:  # pragma: no cover - defensive
+                            app.logger.exception("Unexpected error while scoring image")
+                            errors.append(
+                                f"An unexpected error occurred while scoring {storage.filename or 'a candidate image'}."
+                            )
+                            continue
+
+                        try:
+                            preview = _image_to_data_url(candidate_image)
+                        except ValueError:
+                            errors.append(
+                                f"Could not generate preview for {storage.filename or 'a candidate image'}."
+                            )
+                            preview = None
+
+                        scored_results.append(
+                            {
+                                "name": storage.filename or "Candidate",
+                                "score": float(score),
+                                "orb": float(orb),
+                                "histogram": float(hist),
+                                "ssim": float(ssim),
+                                "preview": preview,
+                            }
+                        )
+
+                    if scored_results:
+                        scored_results.sort(key=lambda item: item["score"], reverse=True)
+                        limit = top_value if top_value > 0 else len(scored_results)
+                        results = scored_results[:limit]
+                    else:
+                        results = []
+
+        payload = {
+            "errors": errors,
+            "weights": [float(value) for value in weights],
+            "top": top_value,
+            "query_preview": query_preview,
+            "results": results or [],
+            "submitted": request.method == "POST",
+        }
+        wants_json = request.method == "POST" and request.accept_mimetypes.best == "application/json"
+        if wants_json:
+            status_code = 200 if not errors else 400
+            return jsonify(payload), status_code
+
+        return render_template(
+            "index.html",
+            weights=weights,
+            top=top_value,
+            results=results if request.method == "POST" else None,
+            errors=errors,
+            query_preview=query_preview,
+            submitted=request.method == "POST",
+            placeholder_text="Results will appear here after you compare images.",
+            initial_payload=payload,
+        )
+
+    return app
+
+
+def _file_to_image(storage) -> np.ndarray:
+    """Decode an uploaded file into a BGR OpenCV image."""
+    storage.stream.seek(0)
+    file_bytes = storage.read()
+    if not file_bytes:
+        raise ValueError("Empty upload")
+    array = np.frombuffer(file_bytes, dtype=np.uint8)
+    image = cv2.imdecode(array, cv2.IMREAD_COLOR)
+    if image is None:
+        raise ValueError("Invalid image data")
+    return image
+
+
+def _image_to_data_url(image: np.ndarray) -> str:
+    """Convert an image array to a base64 data URL for inline display."""
+    success, buffer = cv2.imencode(".jpg", image)
+    if not success:
+        raise ValueError("Unable to encode image")
+    encoded = base64.b64encode(buffer.tobytes()).decode("utf-8")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+app = create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- rebuild the Flask template with a simplified layout and client-side rendering so comparisons update without reloading the page
- restyle the upload and results panels to a tidy dark theme with clearer grouping for weights, previews, and scores
- return structured JSON payloads from the Flask view with safe numeric values to drive the asynchronous front-end updates

## Testing
- python -m compileall fuzzy_image_matching

------
https://chatgpt.com/codex/tasks/task_e_68db86319280832c8251207d77583df7